### PR TITLE
remove duplicate dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
-    "@babel/preset-env": "^7.6.3",
     "@babel/preset-env": "^7.8.7",
     "@babel/preset-react": "^7.8.3",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
package `@babel/preset-env` is required twice, removed the older required version