### PR TITLE
fix javascript block warnings

### DIFF
--- a/src/client/components/Header.js
+++ b/src/client/components/Header.js
@@ -21,7 +21,7 @@ const Header = () => {
             <a href="/" className="brand-logo">
               SSR News
             </a>
-            <a href="javascript:void(0)" onClick={toggleMenu} className="sidenav-trigger right">
+            <a onClick={toggleMenu} className="sidenav-trigger waves-effect right">
               <i className="material-icons">menu</i>
             </a>
             <div

--- a/src/client/pages/ArticleListPage.js
+++ b/src/client/pages/ArticleListPage.js
@@ -32,7 +32,7 @@ const ArticleListPage = props => {
             <span className="card-title">{article.title}</span>
           </div>
           <div className="card-action">
-            <a href="javascript:void(0)" onClick={() => readArticle(article)}>
+            <a className="waves-effect waves-light" onClick={() => readArticle(article)}>
               Read More
             </a>
           </div>

--- a/src/client/pages/HomePage.js
+++ b/src/client/pages/HomePage.js
@@ -32,7 +32,7 @@ const HomePage = props => {
             <span className="card-title">{article.title}</span>
           </div>
           <div className="card-action">
-            <a href="javascript:void(0)" onClick={() => readArticle(article)}>
+            <a className="waves-effect waves-light" onClick={() => readArticle(article)}>
               Read More
             </a>
           </div>


### PR DESCRIPTION
Fixing bug of using `javascript:` through `a` links.

```
Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed "javascript:void(1)".
    in a
    in div
    in div
    in div
    in div
    in div
    in div
    in div
    in P
    in Context.Provider
    in ConnectFunction
    in ConnectFunction
    in Context.Provider
    in Context.Consumer
    in Route
    in Context.Consumer
    in Switch
    in c
    in div
    in div
    in X
    in Context.Provider
    in Context.Consumer
    in Route
    in Context.Consumer
    in Switch
    in div
    in Context.Provider
    in Context.Provider
    in Router
    in StaticRouter
    in Context.Provider
    in Provider
```

See the discussion: https://github.com/facebook/react/issues/16382